### PR TITLE
fix: add warning for missing Java/Python requirements in installation guide

### DIFF
--- a/docs/04-get-started/03-get-started-installer.md
+++ b/docs/04-get-started/03-get-started-installer.md
@@ -54,13 +54,13 @@ TDengine IDMP 依赖 TDengine TSDB-Enterprise 3.3.7.0+, 在安装 TDengine IDMP 
 关于服务启动、停止更详细的操作指南，请您参考[使用安装包部署](../operation/installation/install-guide)章节。为了简化安装包的部署，您还可以使用我们提供的 Ansible Playbook 来完成安装和配置，具体步骤请参考[使用 Ansible Playbook 部署](../operation/installation/ansible-guide)章节。
 
 :::tip
-Q：在安装过程中，安装程序会自动下载并安装 AI 相关的 Python 依赖，如果遇到"Failed to install TDengine IDMP dependencies from /usr/local/taos/idmp/chat/requirements.txt"的错误提示
-
-A：请确保您的系统已连接互联网，在国内的网络中还可以通过替换 PyPI 镜像源，例如：[清华大学的 PyPI 镜像源](https://pypi.tuna.tsinghua.edu.cn/)，来加速下载。
-```bash
-pip config set global.index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
-```
-
+1. 安装过程中，如果遇到以下错误 "Failed to install TDengine IDMP dependencies from /usr/local/taos/idmp/chat/requirements.txt", 应该如何解决？
+   - IDMP 安装过程中，需要访问互联网，以安装 AI 相关的 Python 依赖，请确保您的系统已连接互联网。
+   - 网络连接正常的情况下，请确保 PyPI 仓库可以正常访问。在国内的网络中，建议配置 PyPI 镜像源来加速下载，例如：[清华大学的 PyPI 镜像源](https://pypi.tuna.tsinghua.edu.cn/)，具体命令如下：
+     ```bash
+     pip config set global.index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
+     ```
+   - 更详细的安装日志，请参考：/tmp/tdengine_chat_dep_install.log
 :::
 
 import Init from './_init.md'

--- a/docs/07-operation/02-installation/01-install-guide.md
+++ b/docs/07-operation/02-installation/01-install-guide.md
@@ -62,17 +62,16 @@ TDengine IDMP 依赖 TDengine TSDB-Enterprise 3.3.7.0+, 在安装 TDengine IDMP 
 
 </Tabs>
 
-:::warning
-Q：安装过程打印 "Java Version 21+ /Python Version 3.10+ is required, but command not found at SYSTEM_PATH:" 
+:::tip
+IDMP 的正常运行，依赖指定版本的 Python 和 Java 环境。在安装过程中，安装脚本会对依赖进行检查。常见错误如下，以 Java 为例：
 
-A：说明打印的系统环境变量中没有找到 Java 或 Python 的命令行，需要安装 Java 或者 Python
+1. 安装过程中，如果遇到以下错误 "Java Version 21+ is required, but not found at: ...", 应该如何解决？
+   - Java 没有安装，请安装 Java 21 或更高版本。
+   - Java 已安装，但安装程序没有找到，可以通过创建软链接的方式来解决，例如：`ln -s /path/to/your-java-executable /usr/local/bin/java`.
 
-Q：安装过程打印"Java Version 21+ /Python Version 3.10+ is required and not found at:"的失败提示，说明打印的系统环境变量中没有找到符合要求版本的 Java 或 Python。
-
-A：说明打印的系统环境变量中没有找到 Java 或 Python 的正确版本，你可以备份不支持的 Java 或者 Python 版本，然后通过设置软链接，把对应的正确版本的可执行文件添加到打印的系统环境变量目录中。
-```
-ln -s /path/to/your-java-executable /usr/local/bin/java 
-```
+2. 安装过程中，如果遇到以下错误 "Java Version 21+ is required, but version X is found at: ...", 应该如何解决？ 
+   - Java 版本过低，请安装 Java 21 或更高版本。
+   - 满足要求的 Java 已安装，但安装程序没有找到，可以通过创建软链接的方式来解决，例如：`ln -s /path/to/your-java-executable /usr/local/bin/java`, 如果系统中存在多个 Java 版本，请注意 PATH 的优先级。在以上报错信息中，会打印 PATH 的搜索路径，请您确保满足要求的 Java 可执行文件在 PATH 中的优先级最高。
 :::
 
 ## 配置


### PR DESCRIPTION
fix: add warning for missing Java/Python requirements in installationguide