### PR TITLE
feat: lock python version to 3.12 in doc

### DIFF
--- a/docs/04-get-started/03-get-started-installer.md
+++ b/docs/04-get-started/03-get-started-installer.md
@@ -11,7 +11,7 @@ TDengine IDMP 提供了丰富的功能，本文档将带领您通过安装包完
 TDengine IDMP 支持多种安装、部署方式，在不同的操作系统和架构下，都能够体验其强大的功能带来的便利。对操作系统和架构的支持，详见[部署规划](../operation/planning)。
 
 TDengine IDMP 的运行还需要满足以下先决条件：
-* Python: 3.10-3.12 版本
+* Python: 3.12 版本
 * Java: 21 及以上版本
 * glibc: 2.25 及以上版本
 

--- a/docs/07-operation/01-planning.md
+++ b/docs/07-operation/01-planning.md
@@ -23,7 +23,7 @@
 ## 基础依赖
 
 TDengine IDMP 的运行需要以下基础依赖：
-  * Python: 3.10-3.12 版本
+  * Python: 3.12 版本
   * Java: 21 及以上版本
   * glibc: 2.25 及以上版本
 

--- a/docs/07-operation/02-installation/01-install-guide.md
+++ b/docs/07-operation/02-installation/01-install-guide.md
@@ -11,7 +11,7 @@ TDengine IDMP 依赖 TDengine TSDB-Enterprise 3.3.7.0+, 在安装 TDengine IDMP 
 
 除了 TDengine TSDB-Enterprise 以外，TDengine IDMP 的运行还需要满足以下先决条件：
 
-1. Python: 3.10-3.12 版本
+1. Python: 3.12 版本
 1. Java: 21 及以上版本
 1. glibc: 2.25 及以上版本
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/04-get-started/03-get-started-installer.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/04-get-started/03-get-started-installer.md
@@ -17,7 +17,7 @@ You can install TDengine IDMP locally on a Linux or macOS machine. In this docum
 - Install TDengine TSDB-Enterprise version 3.3.7.0 or higher. For instructions, see [Deploy TDengine TSDB-Enterprise](https://docs.tdengine.com/get-started/deploy-enterprise-edition/).
 - Install Java 21 or later.
 - Install glibc 2.25 or later.
-- Install Python 3.10 to 3.12.
+- Install Python 3.12.
 - On Debian and Ubuntu systems, install the `python3-venv` package.
 
 ## Install TDengine IDMP

--- a/i18n/en/docusaurus-plugin-content-docs/current/07-operation/01-planning.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/07-operation/01-planning.md
@@ -26,7 +26,7 @@ TDengine IDMP currently supports the following operating systems and architectur
 
 The following dependencies are required to run TDengine IDMP:
 
-- Python 3.10 to 3.12
+- Python 3.12
 - Java 21 or later
 - glibc 2.25 or later
 


### PR DESCRIPTION
Signed-off-by: WANG Xu <feici02@outlook.com>

# Description

Change Python version requirement from 3.10-3.12 to 3.12.

Jira: https://jira.taosdata.com:18080/browse/TD-37977

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [ ] Are the test cases passed and automated?
- [ ] Is there no significant decrease in test coverage?
