### PR TITLE
fix: add isReleaseHistoryCategory function to improve sorting of release notes

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,3 @@
-packages:
-  - '.'
-
 minimumReleaseAge: 10080
 
 blockExoticSubdeps: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - '.'
+
 minimumReleaseAge: 10080
 
 blockExoticSubdeps: true

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -23,7 +23,7 @@ const customSidebarItemsGenerator = async ({
 
         // Fallback to category link id/path so sorting survives label changes.
         const linkId = item.link?.id || '';
-        return /(^|\/)21-release-history\/index$/.test(linkId);
+        return /(^|\/)\d*-?release-history\/index$/.test(linkId);
     }
 
     function sortReleaseHistory(items) {

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -5,6 +5,27 @@ const customSidebarItemsGenerator = async ({
     defaultSidebarItemsGenerator,
     ...args
 }) => {
+    function isReleaseHistoryCategory(item) {
+        if (item?.type !== 'category' || !Array.isArray(item.items)) {
+            return false;
+        }
+
+        const releaseLabels = new Set([
+            'Release Notes',
+            'Release History',
+            '发布说明',
+            '发布历史'
+        ]);
+
+        if (releaseLabels.has(item.label)) {
+            return true;
+        }
+
+        // Fallback to category link id/path so sorting survives label changes.
+        const linkId = item.link?.id || '';
+        return /(^|\/)21-release-history\/index$/.test(linkId);
+    }
+
     function sortReleaseHistory(items) {
         // Debug logs for version extraction and sorting
         // To enable debug logs, set DEBUG_RELEASE_SORT=true
@@ -52,11 +73,7 @@ const customSidebarItemsGenerator = async ({
 
     function deepSort(items) {
         return items.map(item => {
-            if (
-                item.type === 'category' &&
-                item.label === 'Release Notes' &&
-                Array.isArray(item.items)
-            ) {
+            if (isReleaseHistoryCategory(item)) {
                 // Sort version entries under "Release Notes"
                 return { ...item, items: sortReleaseHistory(item.items) };
             } else if (Array.isArray(item.items)) {


### PR DESCRIPTION
This pull request improves the logic for identifying and sorting release history categories in the sidebar generation code. The main change is the introduction of a more robust function to detect release history categories, making the sorting process more reliable and adaptable to label changes.

**Enhancements to sidebar category detection and sorting:**

* Added the `isReleaseHistoryCategory` function to identify release history categories by checking multiple possible labels (including localized ones) and by matching category link IDs, making the detection more flexible and less dependent on the exact label text.
* Updated the `deepSort` function to use `isReleaseHistoryCategory` instead of checking for a specific label, ensuring that sorting of release history items is applied consistently even if category labels change.

issue：
https://project.feishu.cn/taosdata_td/job/detail/6955576259