### PR TITLE
fix: smaller search box width

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -232,7 +232,7 @@ html[lang^="zh"] .markdown table th:first-child a {
 
 .DocSearch-Button {
   border-radius: 0.25rem !important;
-  width: 35%;
+  width: 28%;
 }
 
 .DocSearch-Button-Keys {


### PR DESCRIPTION
set smaller width for search box to prevent version selector from becoming two lines