### PR TITLE
feat: deploy CN/EN docs separately and fix macOS package fallback

### DIFF
--- a/.github/workflows/deploy_docs.yaml
+++ b/.github/workflows/deploy_docs.yaml
@@ -65,15 +65,29 @@ jobs:
             --auth-mode key
           echo "Uploaded EN docs to Azure Blob Storage"
 
-    - name: Purge Azure CDN Endpoint
+    - name: Purge Azure CDN Endpoint (CN)
       uses: azure/cli@v2
       with:
         azcliversion: ${{ env.AZ_CLI_VERSION }}
         inlineScript: |
-          az cdn endpoint purge \
+          az afd endpoint purge \
             --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-            --profile-name ${{ secrets.AZURE_CDN_PROFILE }} \
-            --name ${{ secrets.AZURE_CDN_ENDPOINT }} \
+            --profile-name ${{ secrets.AZURE_CDN_PROFILE_CN }} \
+            --endpoint-name ${{ secrets.AZURE_CDN_ENDPOINT_CN }} \
+            --domains idmpdocs.taosdata.com \
+            --content-paths  "/*" "/index.html" "/"
+          echo "Azure CDN purged for idmpdocs.taosdata.com"
+
+    - name: Purge Azure CDN Endpoint (EN)
+      uses: azure/cli@v2
+      with:
+        azcliversion: ${{ env.AZ_CLI_VERSION }}
+        inlineScript: |
+          az afd endpoint purge \
+            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
+            --profile-name ${{ secrets.AZURE_CDN_PROFILE_EN }} \
+            --endpoint-name ${{ secrets.AZURE_CDN_ENDPOINT_EN }} \
+            --domains idmpdocs.tdengine.com \
             --content-paths  "/*" "/index.html" "/"
           echo "Azure CDN purged for idmpdocs.tdengine.com"
 

--- a/src/components/PkgListEn/index.js
+++ b/src/components/PkgListEn/index.js
@@ -30,13 +30,46 @@ export default function PkgList({
         const product = data.find((p) => p?.name === productName);
         const pkgVersion = versionProp || product?.filters?.versions[0];
         const all = product?.versions || [];
-        const matchedVersions = all.filter(
+        let matchedVersions = all.filter(
             (v) =>
                 v?.version === pkgVersion &&
                 v?.platform === platform &&
                 (!arch || v?.arch === arch) &&
                 (!pkgType || v?.["pkg-type"] === pkgType)
         );
+        // Fallback: if no packages found for the target version on this platform,
+        // use the latest available version for this platform.
+        if (matchedVersions.length === 0 && !versionProp) {
+            const platformVersions = all.filter(
+                (v) =>
+                    v?.platform === platform &&
+                    (!arch || v?.arch === arch) &&
+                    (!pkgType || v?.["pkg-type"] === pkgType)
+            );
+            if (platformVersions.length > 0) {
+                const latestVersion = platformVersions[0]?.version;
+                matchedVersions = platformVersions.filter(
+                    (v) => v?.version === latestVersion
+                );
+            }
+        }
+        // Fallback for macOS: infer .0 version URL from current version pattern
+        if (matchedVersions.length === 0 && platform === "macOS" && pkgVersion) {
+            const parts = pkgVersion.split(".");
+            if (parts.length === 4) {
+                parts[3] = "0";
+                const macVersion = parts.join(".");
+                const productSlug = productName.toLowerCase().replace(/\s+/g, "-");
+                matchedVersions = [{
+                    name: `${productSlug}-${macVersion}-macos-arm64.pkg`,
+                    "download-url": `https://downloads.taosdata.com/${productSlug}/${macVersion}/${productSlug}-${macVersion}-macos-arm64.pkg`,
+                    version: macVersion,
+                    platform: "macOS",
+                    arch: "arm64",
+                    size: "",
+                }];
+            }
+        }
         const seen = new Set();
         return matchedVersions.filter((v) => {
             const url = v?.["download-url"];
@@ -92,7 +125,7 @@ export default function PkgList({
             <ul>
                 {pkgs.map((p, idx) => (
                     <li key={p['download-url']} >
-                        <button className={styles.packageItem} onClick={() => openPopup(p)}>{p.name} ({p.size})</button>
+                        <button className={styles.packageItem} onClick={() => openPopup(p)}>{p.name}{p.size ? ` (${p.size})` : ''}</button>
                     </li>
                 ))}
             </ul>

--- a/src/components/PkgListZh/index.js
+++ b/src/components/PkgListZh/index.js
@@ -30,13 +30,46 @@ export default function PkgList({
         const product = data.find((p) => p?.name === productName);
         const pkgVersion = versionProp || product?.filters?.versions[0];
         const all = product?.versions || [];
-        const matchedVersions = all.filter(
+        let matchedVersions = all.filter(
             (v) =>
                 v?.version === pkgVersion &&
                 v?.platform === platform &&
                 (!arch || v?.arch === arch) &&
                 (!pkgType || v?.["pkg-type"] === pkgType)
         );
+        // Fallback: if no packages found for the target version on this platform,
+        // use the latest available version for this platform.
+        if (matchedVersions.length === 0 && !versionProp) {
+            const platformVersions = all.filter(
+                (v) =>
+                    v?.platform === platform &&
+                    (!arch || v?.arch === arch) &&
+                    (!pkgType || v?.["pkg-type"] === pkgType)
+            );
+            if (platformVersions.length > 0) {
+                const latestVersion = platformVersions[0]?.version;
+                matchedVersions = platformVersions.filter(
+                    (v) => v?.version === latestVersion
+                );
+            }
+        }
+        // Fallback for macOS: infer .0 version URL from current version pattern
+        if (matchedVersions.length === 0 && platform === "macOS" && pkgVersion) {
+            const parts = pkgVersion.split(".");
+            if (parts.length === 4) {
+                parts[3] = "0";
+                const macVersion = parts.join(".");
+                const productSlug = productName.toLowerCase().replace(/\s+/g, "-");
+                matchedVersions = [{
+                    name: `${productSlug}-${macVersion}-macos-arm64.pkg`,
+                    "download-url": `https://downloads.taosdata.com/${productSlug}/${macVersion}/${productSlug}-${macVersion}-macos-arm64.pkg`,
+                    version: macVersion,
+                    platform: "macOS",
+                    arch: "arm64",
+                    size: "",
+                }];
+            }
+        }
         const seen = new Set();
         return matchedVersions.filter((v) => {
             const url = v?.["download-url"];
@@ -92,7 +125,7 @@ export default function PkgList({
             <ul>
                 {pkgs.map((p, idx) => (
                     <li key={p['download-url']} >
-                        <button className={styles.packageItem} onClick={() => openPopup(p)}>{p.name} ({p.size})</button>
+                        <button className={styles.packageItem} onClick={() => openPopup(p)}>{p.name}{p.size ? ` (${p.size})` : ''}</button>
                     </li>
                 ))}
             </ul>


### PR DESCRIPTION

# Description

- Upload CN docs to $web, EN docs to $web/build-en
- Add separate CDN purge for CN and EN endpoints (az afd endpoint purge)
- Add EN site to Algolia docsearch config
- Fix macOS package list: infer .0 version URL when not in JSON

# Issue(s)

- Close/close/Fix/fix/Resolve/resolve: Issue Link

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [ ] Are the test cases passed and automated?
- [ ] Is there no significant decrease in test coverage?
