### PR TITLE
docs: add Docker Compose certificate configuration for Excel Add-In

### DIFF
--- a/docs/10-excel-add-in/02-certificate-configuration.md
+++ b/docs/10-excel-add-in/02-certificate-configuration.md
@@ -120,6 +120,9 @@ openssl x509 -in certbundle.pem -text -noout | grep -A1 "Subject Alternative Nam
 
 ### 替换证书
 
+<Tabs>
+<TabItem value="package" label="安装包部署">
+
 1. 备份现有证书：
 
    ```bash
@@ -128,12 +131,77 @@ openssl x509 -in certbundle.pem -text -noout | grep -A1 "Subject Alternative Nam
    mv privkey.pem certbundle.pem bak/
    ```
 
-2. 将新生成的 `privkey.pem` 和 `certbundle.pem` 复制到 `/usr/local/taos/idmp/config` 目录：
+2. 将新生成的 `privkey.pem` 和 `certbundle.pem` 复制到 `/usr/local/taos/idmp/config` 目录。
 
-   - **安装包部署：** 直接复制替换即可。
-   - **Docker 部署：** 使用 `docker cp` 将文件复制到容器中，或通过映射 `config` 目录进行替换。
+3. 重启 IDMP 服务使证书生效：
 
-3. 重启 IDMP 服务使证书生效。
+   ```bash
+   systemctl restart idmp
+   ```
+
+</TabItem>
+<TabItem value="docker-compose" label="Docker Compose 部署">
+
+Docker Compose 部署有两种方式配置证书：**卷挂载（推荐）** 和 **docker cp**。
+
+#### 方式一：卷挂载（推荐）
+
+通过在 `docker-compose.yml` 中添加卷挂载，将宿主机上的证书文件映射到容器内。这种方式更新证书时只需替换宿主机文件并重启容器即可。
+
+1. 在宿主机上创建证书目录，并将生成的证书文件放入：
+
+   ```bash
+   mkdir -p /opt/idmp/certs
+   cp privkey.pem certbundle.pem /opt/idmp/certs/
+   ```
+
+2. 编辑 `docker-compose.yml`，在 `tdengine-idmp` 服务的 `volumes` 部分添加证书文件的映射：
+
+   ```yaml
+   services:
+     tdengine-idmp:
+       # ... 其他配置 ...
+       volumes:
+         - idmp_data:/var/lib/taos
+         - idmp_log:/var/log/taos
+         - /opt/idmp/certs/privkey.pem:/usr/local/taos/idmp/config/privkey.pem:ro
+         - /opt/idmp/certs/certbundle.pem:/usr/local/taos/idmp/config/certbundle.pem:ro
+   ```
+
+   :::tip
+   `:ro` 表示只读挂载，防止容器内进程意外修改证书文件。
+   :::
+
+3. 重启 IDMP 容器使证书生效：
+
+   ```bash
+   docker compose down
+   docker compose up -d
+   ```
+
+#### 方式二：docker cp
+
+如果不想修改 `docker-compose.yml`，可以使用 `docker cp` 将证书文件直接复制到运行中的容器内。
+
+1. 将证书文件复制到容器中：
+
+   ```bash
+   docker cp privkey.pem tdengine-idmp:/usr/local/taos/idmp/config/privkey.pem
+   docker cp certbundle.pem tdengine-idmp:/usr/local/taos/idmp/config/certbundle.pem
+   ```
+
+2. 重启容器使证书生效：
+
+   ```bash
+   docker compose restart tdengine-idmp
+   ```
+
+:::warning
+使用 `docker cp` 方式时，如果容器被重建（例如执行 `docker compose down` 后重新 `up`），复制的证书文件将丢失，需要重新执行复制操作。推荐使用卷挂载方式以避免此问题。
+:::
+
+</TabItem>
+</Tabs>
 
 ## 10.2.5 域名解析配置
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/10-excel-add-in/02-certificate-configuration.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/10-excel-add-in/02-certificate-configuration.md
@@ -119,6 +119,9 @@ Ensure that the IDMP HTTPS port (default: **6034**) is in a listening state.
 
 ### Replacing the Certificate
 
+<Tabs>
+<TabItem value="package" label="Package Installation">
+
 1. Back up the existing certificates:
 
    ```bash
@@ -127,12 +130,77 @@ Ensure that the IDMP HTTPS port (default: **6034**) is in a listening state.
    mv privkey.pem certbundle.pem bak/
    ```
 
-2. Copy the newly generated `privkey.pem` and `certbundle.pem` to the `/usr/local/taos/idmp/config` directory:
+2. Copy the newly generated `privkey.pem` and `certbundle.pem` to the `/usr/local/taos/idmp/config` directory.
 
-   - **Package installation:** Copy and replace the files directly.
-   - **Docker deployment:** Use `docker cp` to copy files into the container, or replace through a mapped `config` volume.
+3. Restart the IDMP service for the new certificate to take effect:
 
-3. Restart the IDMP service for the new certificate to take effect.
+   ```bash
+   systemctl restart idmp
+   ```
+
+</TabItem>
+<TabItem value="docker-compose" label="Docker Compose Deployment">
+
+There are two ways to configure certificates in a Docker Compose deployment: **volume mounts (recommended)** and **docker cp**.
+
+#### Option 1: Volume Mounts (Recommended)
+
+Add volume mounts in `docker-compose.yml` to map certificate files from the host into the container. With this approach, updating certificates only requires replacing the files on the host and restarting the container.
+
+1. Create a certificate directory on the host and place the generated certificate files in it:
+
+   ```bash
+   mkdir -p /opt/idmp/certs
+   cp privkey.pem certbundle.pem /opt/idmp/certs/
+   ```
+
+2. Edit `docker-compose.yml` and add certificate file mappings to the `volumes` section of the `tdengine-idmp` service:
+
+   ```yaml
+   services:
+     tdengine-idmp:
+       # ... other configuration ...
+       volumes:
+         - idmp_data:/var/lib/taos
+         - idmp_log:/var/log/taos
+         - /opt/idmp/certs/privkey.pem:/usr/local/taos/idmp/config/privkey.pem:ro
+         - /opt/idmp/certs/certbundle.pem:/usr/local/taos/idmp/config/certbundle.pem:ro
+   ```
+
+   :::tip
+   `:ro` means read-only mount, preventing processes inside the container from accidentally modifying the certificate files.
+   :::
+
+3. Restart the IDMP container for the certificate to take effect:
+
+   ```bash
+   docker compose down
+   docker compose up -d
+   ```
+
+#### Option 2: docker cp
+
+If you prefer not to modify `docker-compose.yml`, you can use `docker cp` to copy certificate files directly into the running container.
+
+1. Copy the certificate files into the container:
+
+   ```bash
+   docker cp privkey.pem tdengine-idmp:/usr/local/taos/idmp/config/privkey.pem
+   docker cp certbundle.pem tdengine-idmp:/usr/local/taos/idmp/config/certbundle.pem
+   ```
+
+2. Restart the container for the certificate to take effect:
+
+   ```bash
+   docker compose restart tdengine-idmp
+   ```
+
+:::warning
+When using `docker cp`, if the container is recreated (e.g., after running `docker compose down` followed by `up`), the copied certificate files will be lost and must be copied again. Volume mounts are recommended to avoid this issue.
+:::
+
+</TabItem>
+</Tabs>
 
 ## 10.2.5 DNS Resolution Configuration
 

--- a/i18n/en/docusaurus-plugin-content-docs/version-1.0.18/10-excel-add-in/02-certificate-configuration.md
+++ b/i18n/en/docusaurus-plugin-content-docs/version-1.0.18/10-excel-add-in/02-certificate-configuration.md
@@ -119,6 +119,9 @@ Ensure that the IDMP HTTPS port (default: **6034**) is in a listening state.
 
 ### Replacing the Certificate
 
+<Tabs>
+<TabItem value="package" label="Package Installation">
+
 1. Back up the existing certificates:
 
    ```bash
@@ -127,12 +130,77 @@ Ensure that the IDMP HTTPS port (default: **6034**) is in a listening state.
    mv privkey.pem certbundle.pem bak/
    ```
 
-2. Copy the newly generated `privkey.pem` and `certbundle.pem` to the `/usr/local/taos/idmp/config` directory:
+2. Copy the newly generated `privkey.pem` and `certbundle.pem` to the `/usr/local/taos/idmp/config` directory.
 
-   - **Package installation:** Copy and replace the files directly.
-   - **Docker deployment:** Use `docker cp` to copy files into the container, or replace through a mapped `config` volume.
+3. Restart the IDMP service for the new certificate to take effect:
 
-3. Restart the IDMP service for the new certificate to take effect.
+   ```bash
+   systemctl restart idmp
+   ```
+
+</TabItem>
+<TabItem value="docker-compose" label="Docker Compose Deployment">
+
+There are two ways to configure certificates in a Docker Compose deployment: **volume mounts (recommended)** and **docker cp**.
+
+#### Option 1: Volume Mounts (Recommended)
+
+Add volume mounts in `docker-compose.yml` to map certificate files from the host into the container. With this approach, updating certificates only requires replacing the files on the host and restarting the container.
+
+1. Create a certificate directory on the host and place the generated certificate files in it:
+
+   ```bash
+   mkdir -p /opt/idmp/certs
+   cp privkey.pem certbundle.pem /opt/idmp/certs/
+   ```
+
+2. Edit `docker-compose.yml` and add certificate file mappings to the `volumes` section of the `tdengine-idmp` service:
+
+   ```yaml
+   services:
+     tdengine-idmp:
+       # ... other configuration ...
+       volumes:
+         - idmp_data:/var/lib/taos
+         - idmp_log:/var/log/taos
+         - /opt/idmp/certs/privkey.pem:/usr/local/taos/idmp/config/privkey.pem:ro
+         - /opt/idmp/certs/certbundle.pem:/usr/local/taos/idmp/config/certbundle.pem:ro
+   ```
+
+   :::tip
+   `:ro` means read-only mount, preventing processes inside the container from accidentally modifying the certificate files.
+   :::
+
+3. Restart the IDMP container for the certificate to take effect:
+
+   ```bash
+   docker compose down
+   docker compose up -d
+   ```
+
+#### Option 2: docker cp
+
+If you prefer not to modify `docker-compose.yml`, you can use `docker cp` to copy certificate files directly into the running container.
+
+1. Copy the certificate files into the container:
+
+   ```bash
+   docker cp privkey.pem tdengine-idmp:/usr/local/taos/idmp/config/privkey.pem
+   docker cp certbundle.pem tdengine-idmp:/usr/local/taos/idmp/config/certbundle.pem
+   ```
+
+2. Restart the container for the certificate to take effect:
+
+   ```bash
+   docker compose restart tdengine-idmp
+   ```
+
+:::warning
+When using `docker cp`, if the container is recreated (e.g., after running `docker compose down` followed by `up`), the copied certificate files will be lost and must be copied again. Volume mounts are recommended to avoid this issue.
+:::
+
+</TabItem>
+</Tabs>
 
 ## 10.2.5 DNS Resolution Configuration
 

--- a/versioned_docs/version-1.0.18/10-excel-add-in/02-certificate-configuration.md
+++ b/versioned_docs/version-1.0.18/10-excel-add-in/02-certificate-configuration.md
@@ -120,6 +120,9 @@ openssl x509 -in certbundle.pem -text -noout | grep -A1 "Subject Alternative Nam
 
 ### 替换证书
 
+<Tabs>
+<TabItem value="package" label="安装包部署">
+
 1. 备份现有证书：
 
    ```bash
@@ -128,12 +131,77 @@ openssl x509 -in certbundle.pem -text -noout | grep -A1 "Subject Alternative Nam
    mv privkey.pem certbundle.pem bak/
    ```
 
-2. 将新生成的 `privkey.pem` 和 `certbundle.pem` 复制到 `/usr/local/taos/idmp/config` 目录：
+2. 将新生成的 `privkey.pem` 和 `certbundle.pem` 复制到 `/usr/local/taos/idmp/config` 目录。
 
-   - **安装包部署：** 直接复制替换即可。
-   - **Docker 部署：** 使用 `docker cp` 将文件复制到容器中，或通过映射 `config` 目录进行替换。
+3. 重启 IDMP 服务使证书生效：
 
-3. 重启 IDMP 服务使证书生效。
+   ```bash
+   systemctl restart idmp
+   ```
+
+</TabItem>
+<TabItem value="docker-compose" label="Docker Compose 部署">
+
+Docker Compose 部署有两种方式配置证书：**卷挂载（推荐）** 和 **docker cp**。
+
+#### 方式一：卷挂载（推荐）
+
+通过在 `docker-compose.yml` 中添加卷挂载，将宿主机上的证书文件映射到容器内。这种方式更新证书时只需替换宿主机文件并重启容器即可。
+
+1. 在宿主机上创建证书目录，并将生成的证书文件放入：
+
+   ```bash
+   mkdir -p /opt/idmp/certs
+   cp privkey.pem certbundle.pem /opt/idmp/certs/
+   ```
+
+2. 编辑 `docker-compose.yml`，在 `tdengine-idmp` 服务的 `volumes` 部分添加证书文件的映射：
+
+   ```yaml
+   services:
+     tdengine-idmp:
+       # ... 其他配置 ...
+       volumes:
+         - idmp_data:/var/lib/taos
+         - idmp_log:/var/log/taos
+         - /opt/idmp/certs/privkey.pem:/usr/local/taos/idmp/config/privkey.pem:ro
+         - /opt/idmp/certs/certbundle.pem:/usr/local/taos/idmp/config/certbundle.pem:ro
+   ```
+
+   :::tip
+   `:ro` 表示只读挂载，防止容器内进程意外修改证书文件。
+   :::
+
+3. 重启 IDMP 容器使证书生效：
+
+   ```bash
+   docker compose down
+   docker compose up -d
+   ```
+
+#### 方式二：docker cp
+
+如果不想修改 `docker-compose.yml`，可以使用 `docker cp` 将证书文件直接复制到运行中的容器内。
+
+1. 将证书文件复制到容器中：
+
+   ```bash
+   docker cp privkey.pem tdengine-idmp:/usr/local/taos/idmp/config/privkey.pem
+   docker cp certbundle.pem tdengine-idmp:/usr/local/taos/idmp/config/certbundle.pem
+   ```
+
+2. 重启容器使证书生效：
+
+   ```bash
+   docker compose restart tdengine-idmp
+   ```
+
+:::warning
+使用 `docker cp` 方式时，如果容器被重建（例如执行 `docker compose down` 后重新 `up`），复制的证书文件将丢失，需要重新执行复制操作。推荐使用卷挂载方式以避免此问题。
+:::
+
+</TabItem>
+</Tabs>
 
 ## 10.2.5 域名解析配置
 


### PR DESCRIPTION
# Description

Add detailed instructions for configuring SSL certificates in Docker Compose deployments, including:
- Volume mount method (recommended) with docker-compose.yml examples
- docker cp method with caveats about container recreation

Updated both Chinese and English docs.

# Issue(s)

https://project.feishu.cn/taosdata_td/job/detail/7006340455

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [ ] Are the test cases passed and automated?
- [ ] Is there no significant decrease in test coverage?
